### PR TITLE
Fix title and meta to match this being the community site and change how hero logos layout.

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -2,8 +2,8 @@ require('dotenv').config();
 
 module.exports = {
   siteMetadata: {
-    title: 'Demuxed, the conference for video engineers',
-    description: 'Demuxed, the conference for video engineers.',
+    title: 'Demuxed, the community for engineers working with video.',
+    description: 'Demuxed, the community for engineers working with video.',
   },
   plugins: [
     'gatsby-plugin-react-helmet',
@@ -25,7 +25,7 @@ module.exports = {
     {
       resolve: 'gatsby-plugin-manifest',
       options: {
-        name: 'Demuxed, the conference for video engineers',
+        name: 'Demuxed, the community for engineers working with video.',
         short_name: 'Demuxed',
         start_url: '/',
         background_color: '#efeaf3',

--- a/src/components/HomePage/Hero/HeroEventCard/EventPhotoLink.jsx
+++ b/src/components/HomePage/Hero/HeroEventCard/EventPhotoLink.jsx
@@ -18,7 +18,9 @@ const Img = styled.div`
   left: 0;
   bottom: 0;
   background-image: url(${props => props.eventPhoto});
-  background-size: cover;
+  background-size: contain;
+  background-repeat: no-repeat;
+  background-position: center;
 `;
 
 const EventPhotoLink = ({ url, photoUrl }) => (


### PR DESCRIPTION
* Fix meta to be community, not conference
* Re-style the hero events so that the full logo can be seen:

Before:
![Screenshot 2019-10-02 at 12 14 15](https://user-images.githubusercontent.com/578330/66040075-76fb6300-e50e-11e9-96a4-cf8a135e8019.png)

After:
![Screenshot 2019-10-02 at 12 14 06](https://user-images.githubusercontent.com/578330/66040073-76fb6300-e50e-11e9-8e45-bd68f8457658.png)

