### PR TITLE
Set Events V2 to prod

### DIFF
--- a/src/app/api/update-meetups/route.ts
+++ b/src/app/api/update-meetups/route.ts
@@ -32,7 +32,7 @@ async function getCommunities() {
 }
 
 async function getEvents() {
-  const records = await base('Events V2')
+  const records = await base('Events')
     .select({
       filterByFormula: '{Time Start} >= TODAY()',
     })
@@ -101,7 +101,7 @@ export async function GET() {
         } else {
           log('Event does not exist, creating', community, startTimeISOString);
 
-          const newEvent = await base('Events V2').create({
+          const newEvent = await base('Events').create({
             'Time Start': startTimeISOString,
             Community: [community.id],
             Type: 'Meetup',

--- a/src/app/api/update-meetups/route.ts
+++ b/src/app/api/update-meetups/route.ts
@@ -32,7 +32,7 @@ async function getCommunities() {
 }
 
 async function getEvents() {
-  const records = await base('Events')
+  const records = await base('Events V2')
     .select({
       filterByFormula: '{Time Start} >= TODAY()',
     })
@@ -86,7 +86,6 @@ export async function GET() {
 
         const eventUrl = event.link;
 
-        // todo: this might not work because the API provides lowercase URLs
         const existingEvent = eventUrl
           ? eventRecords.find((r) => r.get('Event URL') === eventUrl.toString())
           : undefined;
@@ -102,8 +101,7 @@ export async function GET() {
         } else {
           log('Event does not exist, creating', community, startTimeISOString);
 
-          // todo: once we're happy with this, remove Dev
-          const newEvent = await base('Events Dev').create({
+          const newEvent = await base('Events V2').create({
             'Time Start': startTimeISOString,
             Community: [community.id],
             Type: 'Meetup',

--- a/src/lib/airtable.ts
+++ b/src/lib/airtable.ts
@@ -10,7 +10,7 @@ export async function getUpcomingEvents(communities?: Community[]) {
   let fetchedCommunities: { [community_id: string]: Community } = {};
 
   const events: CommunityEvent[] = (
-    await base('Events V2')
+    await base('Events')
       .select({
         filterByFormula: '{Time Start} >= TODAY()',
         sort: [

--- a/src/lib/airtable.ts
+++ b/src/lib/airtable.ts
@@ -10,7 +10,7 @@ export async function getUpcomingEvents(communities?: Community[]) {
   let fetchedCommunities: { [community_id: string]: Community } = {};
 
   const events: CommunityEvent[] = (
-    await base('Events')
+    await base('Events V2')
       .select({
         filterByFormula: '{Time Start} >= TODAY()',
         sort: [


### PR DESCRIPTION
So the new api endpoint produces different data than the old one did. You can see, just, a lot fewer fields. That's what was spooking me about the last PR. 

Despite that, the pages that rely on the event data seem to still work when attached to the new schema. Here's the commit where I tested that: [home](https://demuxed-mdciaph6h-demuxed.vercel.app), [meetups](https://demuxed-mdciaph6h-demuxed.vercel.app/meetups)

@mmcc is it ok that the schema changed? If so, let's merge! And to be safe, let's blow away the old events data and run the /api/update-meetups endpoint on this preview branch, since the schemas are a bit different.

<img width="300" alt="" src="https://github.com/demuxed/demuxed.com/assets/8933386/6366fa99-c9c7-42eb-a3cc-4708050a36e8" />
<img width="300" alt="" src="https://github.com/demuxed/demuxed.com/assets/8933386/4ce75e13-befb-4df9-9a81-e080825bd6a2" />
